### PR TITLE
Adjusted default regex to support '|' as delimiter

### DIFF
--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/QuotedStringTokenizerTests.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/QuotedStringTokenizerTests.cs
@@ -41,6 +41,21 @@ namespace TinyCsvParser.Test.Tokenizer
         }
 
         [Test]
+        public void QuotedString_VerticalBarDelimiter_Test()
+        {
+            var tokenizer = new QuotedStringTokenizer('|');
+
+            var input = "1|\"2|3\"|4";
+            var result = tokenizer.Tokenize(input);
+
+            Assert.AreEqual(3, result.Length);
+
+            Assert.AreEqual("1", result[0]);
+            Assert.AreEqual("2|3", result[1]);
+            Assert.AreEqual("4", result[2]);
+        }
+
+        [Test]
         public void QuotedString_ToString_Test()
         {
             var tokenizer = new QuotedStringTokenizer(';');

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RegularExpressions/QuotedStringTokenizer.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RegularExpressions/QuotedStringTokenizer.cs
@@ -27,7 +27,7 @@ namespace TinyCsvParser.Tokenizer.RegularExpressions
 
         private string GetPreparedRegexp(char columnDelimiter)
         {
-            return string.Format("((?<=\")[^\"]*(?=\"({0}|$)+)|(?<={0}|^)[^{0}\"]*(?={0}|$))", columnDelimiter);
+            return string.Format("((?<=\")[^\"]*(?=\"(\\{0}|$)+)|(?<=\\{0}|^)[^\\{0}\"]*(?=\\{0}|$))", columnDelimiter);
         }
 
         public override string ToString()


### PR DESCRIPTION
We have a use case where files have '|' as delimiter. The default regex did not support '|'.

I adjusted it by adding an escape string before the delimiter to be used. I also added a testcase to verify if it works with '|' as a delimiter.