### PR TITLE
Improve error message when trying to map to a property without a setter.

### DIFF
--- a/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvMappingTests.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvMappingTests.cs
@@ -15,6 +15,7 @@ namespace TinyCsvParser.Test.Mapping
         private class SampleEntity
         {
             public int PropertyInt { get; set; }
+			public int GetOnlyPropertyInt { get; }
         }
 
         private class DuplicateMapping : CsvMapping<SampleEntity>
@@ -89,5 +90,19 @@ namespace TinyCsvParser.Test.Mapping
 
             Assert.DoesNotThrow(() => result.ToString());
         }
-    }
+
+		private class GetOnlyIntColumnMapping : CsvMapping<SampleEntity>
+		{
+			public GetOnlyIntColumnMapping()
+			{
+				MapProperty(0, x => x.GetOnlyPropertyInt);
+			}
+		}
+
+		[Test]
+		public void MapEntity_GetOnlyError_Test()
+		{
+			Assert.Throws<InvalidOperationException>(() => new GetOnlyIntColumnMapping());
+		}
+	}
 }

--- a/TinyCsvParser/TinyCsvParser/Reflection/ReflectionUtils.cs
+++ b/TinyCsvParser/TinyCsvParser/Reflection/ReflectionUtils.cs
@@ -63,14 +63,17 @@ namespace TinyCsvParser.Reflection
             ParameterExpression parameter = Expression.Parameter(typeof(TProperty), "param");
 
 #if NETSTANDARD1_3
-            return Expression.Lambda<Action<TEntity, TProperty>>(
-                Expression.Call(instance, propertyInfo.SetMethod, parameter),
-                new ParameterExpression[] { instance, parameter }).Compile();
+			var setMethod = propertyInfo.SetMethod;
 #else
-            return Expression.Lambda<Action<TEntity, TProperty>>(
-                Expression.Call(instance, propertyInfo.GetSetMethod(), parameter),
-                new ParameterExpression[] { instance, parameter }).Compile();
+			var setMethod = propertyInfo.GetSetMethod();
 #endif
+			if (setMethod == null)
+			{
+				throw new InvalidOperationException($"Unable to map to property '{property.Body}' because it does not contain a setter.");
+			}
+			return Expression.Lambda<Action<TEntity, TProperty>>(
+                Expression.Call(instance, setMethod, parameter),
+                new ParameterExpression[] { instance, parameter }).Compile();
         }
 
         public static string GetPropertyNameFromExpression<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> expression)


### PR DESCRIPTION
Previously, if one attempted to map to a property without a setter, it would only give the cryptic message:
`System.ArgumentNullException: 'Value cannot be null.
Parameter name: method'`
With this PR, it now gives a more informative message about what is failing. 
`System.InvalidOperationException: 'Unable to map to property 'x.GetOnlyPropertyInt' because it does not contain a setter.'`