### PR TITLE
First lines can be commented lines

### DIFF
--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/CustomTokenizerTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/CustomTokenizerTest.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Philipp Wagner. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Text;
+using TinyCsvParser.Mapping;
+using TinyCsvParser.Tokenizer;
+
+namespace TinyCsvParser.Test.Tokenizer
+{
+    [TestFixture]
+    public class CustomTokenizerTest
+    {
+        private class CustomTokenizer : ITokenizer
+        {
+            public string[] Tokenize(string input)
+            {
+                return input?.Split(';');
+            }
+        }
+
+        [Test]
+        public void IgnoreCommentedLinesAndHeader()
+        {
+            CsvParserOptions csvParserOptions = new CsvParserOptions(true, "#", new CustomTokenizer());
+            CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
+            CsvStringArrayMapping csvMapper = new CsvStringArrayMapping();
+            CsvParser<string[]> csvParser = new CsvParser<string[]>(csvParserOptions, csvMapper);
+
+            var stringBuilder = new StringBuilder()
+                                .AppendLine("#comment1")
+                                .AppendLine("#comment2")
+                                .AppendLine("FirstName;LastName;BirthDate")
+                                .AppendLine("Philipp;Wagner;1986/05/12")
+                                .AppendLine("Max;Mustermann;2014/01/01");
+
+            var result = csvParser
+                         .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                         .ToList();
+
+            Assert.AreEqual(2, result.Count);
+
+            Assert.IsTrue(result.All(x => x.IsValid));
+
+            Assert.AreEqual("Philipp", result[0].Result[0]);
+            Assert.AreEqual("Wagner", result[0].Result[1]);
+            Assert.AreEqual("1986/05/12", result[0].Result[2]);
+
+            Assert.AreEqual("Max", result[1].Result[0]);
+            Assert.AreEqual("Mustermann", result[1].Result[1]);
+            Assert.AreEqual("2014/01/01", result[1].Result[2]);
+        }
+    }
+}

--- a/TinyCsvParser/TinyCsvParser/CsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParser.cs
@@ -27,9 +27,7 @@ namespace TinyCsvParser
                 throw new ArgumentNullException(nameof(csvData));
             }
 
-            var query = csvData
-                .Skip(options.SkipHeader ? 1 : 0)
-                .AsParallel();
+            var query = csvData.AsParallel();
 
             // If you want to get the same order as in the CSV file, this option needs to be set:
             if (options.KeepOrder)
@@ -38,18 +36,19 @@ namespace TinyCsvParser
             }
 
             query = query
-                .WithDegreeOfParallelism(options.DegreeOfParallelism)
-                .Where(row => !string.IsNullOrWhiteSpace(row.Data));
+                    .WithDegreeOfParallelism(options.DegreeOfParallelism)
+                    .Where(row => !string.IsNullOrWhiteSpace(row.Data));
 
             // Ignore Lines, that start with a comment character:
-            if(!string.IsNullOrWhiteSpace(options.CommentCharacter)) 
+            if (!string.IsNullOrWhiteSpace(options.CommentCharacter))
             {
                 query = query.Where(line => !line.Data.StartsWith(options.CommentCharacter));
             }
-                
+
             return query
-                .Select(line => new TokenizedRow(line.Index, options.Tokenizer.Tokenize(line.Data)))
-                .Select(fields => mapping.Map(fields));
+                   .Skip(options.SkipHeader ? 1 : 0)
+                   .Select(line => new TokenizedRow(line.Index, options.Tokenizer.Tokenize(line.Data)))
+                   .Select(fields => mapping.Map(fields));
         }
 
         public override string ToString()


### PR DESCRIPTION
Hi,

I like this parser :)
Unfortunately, I have faced with a minor issue. I have tried to read a file, where the first line was a commentLine, the second the header and the rest of the dataLines. In this scenario, it used to skip out the first line (commentLine) as header, then started to process the headerLine as dataLine.